### PR TITLE
Lock requests to 2.74.0, as 2.78.0 relies on Node 4 or newer

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "hubot-tube-status": "^0.1.2",
     "hubot-urban": "^1.0.0",
     "hubot-xkcd-image": "^1.0.0",
-    "hubot-youtube": "^0.1.2"
+    "hubot-youtube": "^0.1.2",
+    "request": "2.74.0"
   },
   "engines": {
     "node": "0.12.x"


### PR DESCRIPTION
Connects idio/Chef-Recipes#1235